### PR TITLE
fix: Adjust CSS to allow overflowing source document links to wrap onto new lines in Chat Dialog.

### DIFF
--- a/src/components/Bot.tsx
+++ b/src/components/Bot.tsx
@@ -843,7 +843,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                     {message.type === 'userMessage' && loading() && index() === messages().length - 1 && <LoadingBubble />}
                     {message.type === 'apiMessage' && message.message === '' && loading() && index() === messages().length - 1 && <LoadingBubble />}
                     {message.sourceDocuments && message.sourceDocuments.length && (
-                      <div style={{ display: 'flex', 'flex-direction': 'row', width: '100%' }}>
+                      <div style={{ display: 'flex', 'flex-direction': 'row', width: '100%', 'flex-wrap': 'wrap' }}>
                         <For each={[...removeDuplicateURL(message)]}>
                           {(src) => {
                             const URL = isValidURL(src.metadata.source);


### PR DESCRIPTION
Currently the list of links of returned source documents are not wrapping onto new lines if they exceed the chat ui dialog width and therefore cause a horizontal scroll on overflowing the initial width.