### PR TITLE
Update README.md to include missing disclaimer button text property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ You can also customize chatbot with different configuration
       disclaimer: {
         title: 'Disclaimer',
         message: 'By using this chatbot, you agree to the <a target="_blank" href="https://flowiseai.com/terms">Terms & Condition</a>',
+        buttonText: 'Start Chatting',
       },
       chatWindow: {
         showTitle: true,

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ You can also customize chatbot with different configuration
         title: 'Disclaimer',
         message: 'By using this chatbot, you agree to the <a target="_blank" href="https://flowiseai.com/terms">Terms & Condition</a>',
         buttonText: 'Start Chatting',
+        blurredBackgroundColor: '',  //The color of the blurred background that overlays the chat interface
+        backgroundColor: '',
+        buttonColor: '',
       },
       chatWindow: {
         showTitle: true,

--- a/src/features/bubble/types.ts
+++ b/src/features/bubble/types.ts
@@ -104,6 +104,9 @@ export type DisclaimerPopUpTheme = {
   title?: string;
   message?: string;
   buttonText?: string;
+  blurredBackgroundColor?: string;
+  backgroundColor?: string;
+  buttonColor?: string;  
 };
 
 export type DateTimeToggleTheme = {

--- a/src/features/popup/components/DisclaimerPopup.tsx
+++ b/src/features/popup/components/DisclaimerPopup.tsx
@@ -6,29 +6,48 @@ export type DisclaimerPopupProps = {
   title?: string;
   message?: string;
   buttonText?: string;
+  blurredBackgroundColor?: string;
+  backgroundColor?: string;
+  buttonColor?: string;
 };
 
 export const DisclaimerPopup = (props: DisclaimerPopupProps) => {
-  const [popupProps] = splitProps(props, ['onAccept', 'isOpen', 'title', 'message', 'buttonText']);
+  const [popupProps] = splitProps(props, [
+    'onAccept',
+    'isOpen',
+    'title',
+    'message',
+    'buttonText',
+    'blurredBackgroundColor',    
+    'backgroundColor',
+    'buttonColor',
+  ]);
 
   const handleAccept = () => {
-    props.onAccept?.();
+    popupProps.onAccept?.();
   };
 
   return (
     <Show when={popupProps.isOpen}>
-      <div class="fixed inset-0 rounded-lg flex items-center justify-center bg-black bg-opacity-40 backdrop-blur-sm z-50">
-        <div class="bg-white p-10 rounded-lg shadow-lg max-w-md w-full text-center mx-4 font-sans">
-          <h2 class="text-2xl font-semibold mb-4 flex justify-center items-center">{popupProps.title ?? 'Disclaimer'}</h2>
+      <div
+        class="fixed inset-0 rounded-lg flex items-center justify-center backdrop-blur-sm z-50"
+        style={{ background: popupProps.blurredBackgroundColor || 'rgba(0, 0, 0, 0.4)' }} 
+      >
+        <div class="p-10 rounded-lg shadow-lg max-w-md w-full text-center mx-4 font-sans" 
+          style={{ background: popupProps.backgroundColor || 'white' }}> {/* Background color for the popup */}
+          <h2 class="text-2xl font-semibold mb-4 flex justify-center items-center">
+            {popupProps.title ?? 'Disclaimer'}
+          </h2>
 
           <p
             class="text-gray-700 text-base mb-6"
-            innerHTML={popupProps.message ?? 'By using this chatbot, you acknowledge and accept these terms.'}
+            innerHTML={popupProps.message ?? 'By using this chatbot, you agree to the <a target="_blank" href="https://flowiseai.com/terms">Terms & Condition</a>.'}
           />
 
           <div class="flex justify-center">
             <button
-              class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded focus:outline-none focus:shadow-outline"
+              class="text-white font-bold py-2 px-6 rounded focus:outline-none focus:shadow-outline"
+              style={{ background: popupProps.buttonColor || '#3b82f6' }} // Use buttonColor if provided (default blue)
               onClick={handleAccept}
             >
               {popupProps.buttonText ?? 'Start Chatting'}


### PR DESCRIPTION
I found the disclaimer supports specifying the button text but the property was missing from the readme.
![image](https://github.com/user-attachments/assets/97b5d5b9-ff2f-4776-9812-a17a6a0d6a56)
