### PR TITLE
Updating nav background color to match textinput icon color if avaliable

### DIFF
--- a/src/components/Bot.tsx
+++ b/src/components/Bot.tsx
@@ -1398,7 +1398,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             class="flex flex-row items-center w-full h-[50px] absolute top-0 left-0 z-10"
             style={{
               background: props.bubbleBackgroundColor,
-              color: props.bubbleTextColor,
+              color: props.textInput?.textColor ? props.textInput?.textColor : props.bubbleBackgroundColor,
               'border-top-left-radius': props.isFullPage ? '0px' : '6px',
               'border-top-right-radius': props.isFullPage ? '0px' : '6px',
             }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/50361f2c-455f-414c-b31a-dec4edc24b9d)
We were not able to config this background blue color nav top bar when using "shareChatbot". We wanted to make the top nav background match the Text input send button color. This PR I believe will help achieve this. 