### PR TITLE
Show title of source documents

### DIFF
--- a/src/components/bubbles/BotBubble.tsx
+++ b/src/components/bubbles/BotBubble.tsx
@@ -434,7 +434,7 @@ export const BotBubble = (props: Props) => {
                   const URL = isValidURL(src.metadata.source);
                   return (
                     <SourceBubble
-                      pageContent={URL ? URL.pathname : src.pageContent}
+                      pageContent={src.metadata.title ? src.metadata.title : URL ? URL.pathname : src.pageContent}
                       metadata={src.metadata}
                       onSourceClick={() => {
                         if (URL) {


### PR DESCRIPTION
This pull request includes a small change to the `BotBubble` component in the `src/components/bubbles/BotBubble.tsx` file. The change ensures that the `pageContent` displays the metadata title if available, otherwise, it falls back to the URL pathname or the original page content.

