### PR TITLE
fix gha failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Install flowise-embed-react dependencies
         working-directory: flowise-embed-react
-        run: yarn install --frozen-lockfile
+        run: yarn install
         env:
           HUSKY: '0'
 


### PR DESCRIPTION
Fixes the GitHub Action publish.yml which fails at the `Install flowise-embed-react dependencies` step in the dry-run job because yarn install `--frozen-lockfile` is used on an external repo (FlowiseAI/FlowiseEmbedReact) whose yarn.lock is out of  sync with its package.json. The publish job already handles this correctly by using plain yarn install.   