### PR TITLE
Fix github action for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -331,7 +331,6 @@ jobs:
         run: |
           npm pkg set "version=${NEW_VERSION}"
           npm pkg set "devDependencies.flowise-embed=${NEW_VERSION}"
-          yarn upgrade "flowise-embed@${NEW_VERSION}"
 
       - name: Install flowise-embed-react dependencies
         working-directory: flowise-embed-react


### PR DESCRIPTION
was running into an issue with yarn indicating the lockfile is outdated when running the upgrade. removing this line since it should pick it up from the package.json