### PR TITLE
chore: bump flowise-embed to 3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowise-embed",
-  "version": "3.1.3",
+  "version": "3.1.5",
   "description": "Javascript library to display flowise chatbot on your website",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Automated version bump after publishing `flowise-embed@3.1.5` to npm with tag `latest`.