### PR TITLE
update github action to use github app

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,13 +69,24 @@ jobs:
             fi
           fi
 
+      - name: Generate Flowise Publish Bot Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.FLOWISE_BOT_APP_ID }}
+          private-key: ${{ secrets.FLOWISE_BOT_PRIVATE_KEY }}
+          owner: FlowiseAI
+          repositories: |
+            FlowiseChatEmbed
+            FlowiseEmbedReact
+
       - name: Checkout FlowiseChatEmbed
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
           path: flowise-embed
-          token: ${{ secrets.PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout FlowiseEmbedReact
         uses: actions/checkout@v6
@@ -83,7 +94,7 @@ jobs:
           repository: FlowiseAI/FlowiseEmbedReact
           fetch-depth: 1
           path: flowise-embed-react
-          token: ${{ secrets.PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -197,6 +208,7 @@ jobs:
   # Runs only after a reviewer approves via the npm-publish environment gate.
   # Publishes both packages to npm, then creates version bump PRs.
   publish:
+    if: false
     needs: dry-run
     runs-on: ubuntu-latest
     environment: npm-publish
@@ -204,13 +216,24 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate Flowise Publish Bot Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.FLOWISE_BOT_APP_ID }}
+          private-key: ${{ secrets.FLOWISE_BOT_PRIVATE_KEY }}
+          owner: FlowiseAI
+          repositories: |
+            FlowiseChatEmbed
+            FlowiseEmbedReact
+
       - name: Checkout FlowiseChatEmbed
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 1
           path: flowise-embed
-          token: ${{ secrets.PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout FlowiseEmbedReact
         uses: actions/checkout@v6
@@ -218,7 +241,7 @@ jobs:
           repository: FlowiseAI/FlowiseEmbedReact
           fetch-depth: 1
           path: flowise-embed-react
-          token: ${{ secrets.PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -228,8 +251,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name  "flowise-publish-bot[bot]"
+          git config --global user.email "${{ secrets.FLOWISE_BOT_APP_ID }}+flowise-publish-bot[bot]@users.noreply.github.com"
 
       - name: Log publish intent
         env:
@@ -291,7 +314,7 @@ jobs:
         env:
           VERSION: ${{ needs.dry-run.outputs.version }}
           TAG: ${{ inputs.tag }}
-          GH_TOKEN: ${{ secrets.PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="chore/bump-flowise-embed-${VERSION}"
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
@@ -375,7 +398,7 @@ jobs:
         env:
           VERSION: ${{ needs.dry-run.outputs.version }}
           TAG: ${{ inputs.tag }}
-          GH_TOKEN: ${{ secrets.PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="chore/bump-flowise-embed-react-${VERSION}"
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -250,9 +250,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure git
+        env:
+          APP_ID: ${{ secrets.FLOWISE_BOT_APP_ID }}
         run: |
           git config --global user.name  "flowise-publish-bot[bot]"
-          git config --global user.email "${{ secrets.FLOWISE_BOT_APP_ID }}+flowise-publish-bot[bot]@users.noreply.github.com"
+          git config --global user.email "${APP_ID}+flowise-publish-bot[bot]@users.noreply.github.com"
 
       - name: Log publish intent
         env:


### PR DESCRIPTION
**Summary**
 - Replace `secrets.PAT_GITHUB` with a scoped GitHub App installation token (flowise-publish-bot) in the publish workflow for improved security and auditability
 - Update git commit identity from github PAT identity to `flowise-publish-bot[bot]` so version bump commits are attributed to the bot

 **Why**
 A long-lived PAT has broad user-level scope and never expires. A GitHub App installation token is scoped to only `FlowiseChatEmbed` and `FlowiseEmbedReact`, expires after 1 hour, and auto-rotates per job — significantly reducing blast radius if credentials are ever exposed. Currently because we have to go between the 2 repos we could either have a GHA in each repo that is triggered once one is complete (High complexity) or use a user scoped PAT, which would mean that the PR creation would be under the user's identity

 **Prerequisites**
 - `flowise-publish-bot` GitHub App installed on FlowiseAI org with access to both `FlowiseChatEmbed` and `FlowiseEmbedReact`
 - App has contents: write and pull_requests: write permissions
 - `FLOWISE_BOT_APP_ID` and `FLOWISE_BOT_PRIVATE_KEY` secrets configured
 - Remove if: Will remove after dry run has been tested

 **Test plan**
 - Trigger the workflow via manual trigger with a patch bump and verify the dry-run job succeeds (builds, dry-run publishes, summary renders)
 - Approve the `npm-publish` environment gate and verify the publish job succeeds end-to-end
 - Confirm version bump PRs are created in both repos and attributed to `flowise-publish-bot[bot]`