### PR TITLE
enables publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -208,7 +208,6 @@ jobs:
   # Runs only after a reviewer approves via the npm-publish environment gate.
   # Publishes both packages to npm, then creates version bump PRs.
   publish:
-    if: false
     needs: dry-run
     runs-on: ubuntu-latest
     environment: npm-publish


### PR DESCRIPTION
This enabled the publish action that was previously skipped in #369.

The intention was to test #369 and verify the github app auth would work checking out the repos.

Here is the successful run:
https://github.com/FlowiseAI/FlowiseChatEmbed/actions/runs/24857479611/job/72774089912